### PR TITLE
Fixed energy issues

### DIFF
--- a/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
+++ b/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
@@ -2,12 +2,13 @@ package matteroverdrive.items.includes;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
-import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.energy.EnergyStorage;
 
+import javax.annotation.Nullable;
+
 public class EnergyContainer extends EnergyStorage implements INBTSerializable<NBTTagCompound> {
-    ItemStack stack;
+    private ItemStack stack;
 
     public EnergyContainer(int capacity) {
         super(capacity);
@@ -29,6 +30,11 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
         setEnergy(this.capacity);
     }
 
+    @Nullable
+    public ItemStack getItemStack() {
+        return this.stack;
+    }
+
     public EnergyContainer setItemStack(ItemStack stack) {
         boolean hasTags = stack.hasTagCompound();
         if (!hasTags || !stack.getTagCompound().hasKey("energy")) {
@@ -46,14 +52,14 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
         return this;
     }
 
-    private NBTTagCompound stackTag() {
-        return (NBTTagCompound) stack.getTagCompound().getTag("energy");
+    private NBTTagCompound getStackEnergyTag() {
+        return stack.getTagCompound().getCompoundTag("energy");
     }
 
     @Override
     public int getEnergyStored() {
         if (stack != null) {
-            return stackTag().getInteger("energy");
+            return getStackEnergyTag().getInteger("energy");
         }
 
         return energy;
@@ -62,7 +68,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
     @Override
     public int getMaxEnergyStored() {
         if (stack != null) {
-            return stackTag().getInteger("capacity");
+            return getStackEnergyTag().getInteger("capacity");
         }
 
         return capacity;
@@ -70,7 +76,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public int getMaxExtract() {
         if (stack != null) {
-            return stackTag().getInteger("maxExtract");
+            return getStackEnergyTag().getInteger("maxExtract");
         }
 
         return maxExtract;
@@ -78,7 +84,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public int getMaxReceive() {
         if (stack != null) {
-            return stackTag().getInteger("maxReceive");
+            return getStackEnergyTag().getInteger("maxReceive");
         }
 
         return maxReceive;
@@ -86,7 +92,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public void setEnergy(int energy) {
         if (stack != null) {
-            stackTag().setInteger("energy", energy);
+            getStackEnergyTag().setInteger("energy", energy);
 
             if (getEnergyStored() > getMaxEnergyStored()) {
                 setFull();
@@ -119,7 +125,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
         if (!simulate) {
             if (stack != null && energyReceived != 0) {
-                stackTag().setInteger("energy", getEnergyStored() + energyReceived);
+                getStackEnergyTag().setInteger("energy", getEnergyStored() + energyReceived);
             } else {
                 energy += energyReceived;
             }
@@ -137,7 +143,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
         if (!simulate) {
             if (stack != null && energyExtracted != 0) {
-                stackTag().setInteger("energy", getEnergyStored() - energyExtracted);
+                getStackEnergyTag().setInteger("energy", getEnergyStored() - energyExtracted);
             } else {
                 energy -= energyExtracted;
             }
@@ -164,7 +170,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public void setMaxEnergy(int max) {
         if (stack != null) {
-            stackTag().setInteger("capacity", max);
+            getStackEnergyTag().setInteger("capacity", max);
             return;
         }
 

--- a/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
+++ b/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
@@ -94,7 +94,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
         if (!canReceive())
             return 0;
 
-        int energyReceived = Math.min(capacity - energy, Math.min(getMaxReceive(), amount));
+        int energyReceived = Math.min(getMaxEnergyStored() - getEnergyStored(), Math.min(getMaxReceive(), amount));
 
         if (!simulate) {
             if (stack != null && energyReceived != 0) {

--- a/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
+++ b/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
@@ -1,10 +1,13 @@
 package matteroverdrive.items.includes;
 
+import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.energy.EnergyStorage;
 
 public class EnergyContainer extends EnergyStorage implements INBTSerializable<NBTTagCompound> {
+    ItemStack stack;
+
     public EnergyContainer(int capacity) {
         super(capacity);
     }
@@ -25,6 +28,51 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
         setEnergy(this.capacity);
     }
 
+    public EnergyContainer setItemStack(ItemStack stack) {
+        if (!stack.hasTagCompound()) {
+            NBTTagCompound tag = serializeNBT();
+            stack.setTagCompound(tag);
+        }
+
+        deserializeNBT(stack.getTagCompound());
+        this.stack = stack;
+        return this;
+    }
+
+    @Override
+    public int getEnergyStored() {
+        if (stack != null) {
+            return stack.getTagCompound().getInteger("mo_energystored");
+        }
+
+        return energy;
+    }
+
+    @Override
+    public int getMaxEnergyStored() {
+        if (stack != null) {
+            return stack.getTagCompound().getInteger("mo_capacity");
+        }
+
+        return capacity;
+    }
+
+    public int getMaxExtract() {
+        if (stack != null) {
+            return stack.getTagCompound().getInteger("mo_maxextract");
+        }
+
+        return maxExtract;
+    }
+
+    public int getMaxReceive() {
+        if (stack != null) {
+            return stack.getTagCompound().getInteger("mo_maxreceive");
+        }
+
+        return maxReceive;
+    }
+
     public void setEnergy(int energy) {
         this.energy = energy;
         if (this.energy > this.capacity)
@@ -32,21 +80,65 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
     }
 
     @Override
-    public NBTTagCompound serializeNBT() {
-        NBTTagCompound tag = new NBTTagCompound();
-        tag.setInteger("energy", energy);
-        tag.setInteger("capacity", capacity);
-        tag.setInteger("maxReceive", maxReceive);
-        tag.setInteger("maxExtract", maxExtract);
-        return tag;
+    public boolean canExtract() {
+        return getMaxExtract() > 0;
     }
 
     @Override
+    public boolean canReceive() {
+        return getMaxReceive() > 0;
+    }
+
+    @Override
+    public int receiveEnergy(int amount, boolean simulate) {
+        if (!canReceive())
+            return 0;
+
+        int energyReceived = Math.min(capacity - energy, Math.min(getMaxReceive(), amount));
+
+        if (!simulate) {
+            if (stack != null && energyReceived != 0) {
+                stack.getTagCompound().setInteger("mo_energystored", getEnergyStored() + energyReceived);
+            } else {
+                energy += energyReceived;
+            }
+        }
+
+        return energyReceived;
+    }
+
+    @Override
+    public int extractEnergy(int amount, boolean simulate) {
+        if (!canExtract())
+            return 0;
+
+        int energyExtracted = Math.min(getEnergyStored(), Math.min(getMaxExtract(), amount));
+
+        if (!simulate) {
+            if (stack != null && energyExtracted != 0) {
+                stack.getTagCompound().setInteger("mo_energystored", getEnergyStored() - energyExtracted);
+            } else {
+                energy -= energyExtracted;
+            }
+        }
+
+        return energyExtracted;
+    }
+
+    public NBTTagCompound serializeNBT() {
+        NBTTagCompound tag = new NBTTagCompound();
+        tag.setInteger("mo_energystored", energy);
+        tag.setInteger("mo_capacity", capacity);
+        tag.setInteger("mo_maxreceive", maxReceive);
+        tag.setInteger("mo_maxextract", maxExtract);
+        return tag;
+    }
+
     public void deserializeNBT(NBTTagCompound tag) {
-        energy = tag.getInteger("energy");
-        capacity = tag.getInteger("capacity");
-        maxReceive = tag.getInteger("maxReceive");
-        maxExtract = tag.getInteger("maxExtract");
+        energy = tag.getInteger("mo_energystored");
+        capacity = tag.getInteger("mo_capacity");
+        maxReceive = tag.getInteger("mo_maxreceive");
+        maxExtract = tag.getInteger("mo_maxextract");
     }
 
     public void setMaxEnergy(int max) {

--- a/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
+++ b/src/main/java/matteroverdrive/items/includes/EnergyContainer.java
@@ -42,7 +42,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
     @Override
     public int getEnergyStored() {
         if (stack != null) {
-            return stack.getTagCompound().getInteger("mo_energystored");
+            return stack.getTagCompound().getInteger("energy");
         }
 
         return energy;
@@ -51,7 +51,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
     @Override
     public int getMaxEnergyStored() {
         if (stack != null) {
-            return stack.getTagCompound().getInteger("mo_capacity");
+            return stack.getTagCompound().getInteger("capacity");
         }
 
         return capacity;
@@ -59,7 +59,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public int getMaxExtract() {
         if (stack != null) {
-            return stack.getTagCompound().getInteger("mo_maxextract");
+            return stack.getTagCompound().getInteger("maxExtract");
         }
 
         return maxExtract;
@@ -67,7 +67,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public int getMaxReceive() {
         if (stack != null) {
-            return stack.getTagCompound().getInteger("mo_maxreceive");
+            return stack.getTagCompound().getInteger("maxReceive");
         }
 
         return maxReceive;
@@ -98,7 +98,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
         if (!simulate) {
             if (stack != null && energyReceived != 0) {
-                stack.getTagCompound().setInteger("mo_energystored", getEnergyStored() + energyReceived);
+                stack.getTagCompound().setInteger("energy", getEnergyStored() + energyReceived);
             } else {
                 energy += energyReceived;
             }
@@ -116,7 +116,7 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
         if (!simulate) {
             if (stack != null && energyExtracted != 0) {
-                stack.getTagCompound().setInteger("mo_energystored", getEnergyStored() - energyExtracted);
+                stack.getTagCompound().setInteger("energy", getEnergyStored() - energyExtracted);
             } else {
                 energy -= energyExtracted;
             }
@@ -127,18 +127,18 @@ public class EnergyContainer extends EnergyStorage implements INBTSerializable<N
 
     public NBTTagCompound serializeNBT() {
         NBTTagCompound tag = new NBTTagCompound();
-        tag.setInteger("mo_energystored", energy);
-        tag.setInteger("mo_capacity", capacity);
-        tag.setInteger("mo_maxreceive", maxReceive);
-        tag.setInteger("mo_maxextract", maxExtract);
+        tag.setInteger("energy", energy);
+        tag.setInteger("capacity", capacity);
+        tag.setInteger("maxReceive", maxReceive);
+        tag.setInteger("energy", maxExtract);
         return tag;
     }
 
     public void deserializeNBT(NBTTagCompound tag) {
-        energy = tag.getInteger("mo_energystored");
-        capacity = tag.getInteger("mo_capacity");
-        maxReceive = tag.getInteger("mo_maxreceive");
-        maxExtract = tag.getInteger("mo_maxextract");
+        energy = tag.getInteger("energy");
+        capacity = tag.getInteger("capacity");
+        maxReceive = tag.getInteger("maxReceive");
+        maxExtract = tag.getInteger("maxExtract");
     }
 
     public void setMaxEnergy(int max) {

--- a/src/main/java/matteroverdrive/items/includes/MOItemEnergyContainer.java
+++ b/src/main/java/matteroverdrive/items/includes/MOItemEnergyContainer.java
@@ -31,9 +31,11 @@ import net.minecraft.world.World;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.capabilities.ICapabilitySerializable;
+import net.minecraftforge.common.util.INBTSerializable;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.List;
 
@@ -45,9 +47,7 @@ public abstract class MOItemEnergyContainer extends MOBaseItem {
     }
 
     public static IEnergyStorage getStorage(ItemStack stack) {
-        if (stack.hasCapability(CapabilityEnergy.ENERGY, null))
-            return stack.getCapability(CapabilityEnergy.ENERGY, null);
-        return EmptyEnergyStorage.INSTANCE;
+        return stack.getCapability(CapabilityEnergy.ENERGY, null);
     }
 
     @Override
@@ -61,7 +61,7 @@ public abstract class MOItemEnergyContainer extends MOBaseItem {
     }
 
     @Override
-    public double getDurabilityForDisplay(ItemStack stack) {
+    public double getDurabilityForDisplay(@Nonnull ItemStack stack) {
         IEnergyStorage storage = getStorage(stack);
         return (storage.getMaxEnergyStored() - storage.getEnergyStored()) / (double) storage.getMaxEnergyStored();
     }
@@ -82,8 +82,8 @@ public abstract class MOItemEnergyContainer extends MOBaseItem {
         return true;
     }
 
-    public ICapabilitySerializable<NBTTagCompound> createProvider(ItemStack stack) {
-        return new EnergyProvider(getCapacity(), getInput(), getOutput());
+    public ICapabilityProvider createProvider(ItemStack stack) {
+        return new EnergyProvider(getCapacity(), getInput(), getOutput()).setStack(stack);
     }
 
     protected abstract int getCapacity();
@@ -112,16 +112,20 @@ public abstract class MOItemEnergyContainer extends MOBaseItem {
 
     @Nullable
     @Override
-    public ICapabilityProvider initCapabilities(ItemStack stack, @Nullable NBTTagCompound nbt) {
+    public ICapabilityProvider initCapabilities(@Nonnull ItemStack stack, @Nullable NBTTagCompound nbt) {
         return createProvider(stack);
     }
 
-    public static class EnergyProvider implements ICapabilitySerializable<NBTTagCompound> {
-
+    public static class EnergyProvider implements ICapabilityProvider {
         private EnergyContainer container;
 
         public EnergyProvider(int capacity, int input, int output) {
             container = new EnergyContainer(capacity, input, output);
+        }
+
+        public EnergyProvider setStack(ItemStack stack) {
+            container.setItemStack(stack);
+            return this;
         }
 
         public EnergyProvider(int capacity, int through) {
@@ -139,17 +143,8 @@ public abstract class MOItemEnergyContainer extends MOBaseItem {
             if (capability == CapabilityEnergy.ENERGY) {
                 return CapabilityEnergy.ENERGY.cast(container);
             }
+
             return null;
-        }
-
-        @Override
-        public NBTTagCompound serializeNBT() {
-            return container.serializeNBT();
-        }
-
-        @Override
-        public void deserializeNBT(NBTTagCompound tag) {
-            container.deserializeNBT(tag);
         }
     }
 }

--- a/src/main/java/matteroverdrive/items/includes/MOItemEnergyContainer.java
+++ b/src/main/java/matteroverdrive/items/includes/MOItemEnergyContainer.java
@@ -47,7 +47,9 @@ public abstract class MOItemEnergyContainer extends MOBaseItem {
     }
 
     public static IEnergyStorage getStorage(ItemStack stack) {
-        return stack.getCapability(CapabilityEnergy.ENERGY, null);
+        if (stack.hasCapability(CapabilityEnergy.ENERGY, null))
+            return stack.getCapability(CapabilityEnergy.ENERGY, null);
+        return EmptyEnergyStorage.INSTANCE;
     }
 
     @Override

--- a/src/main/java/matteroverdrive/tile/MOTileEntityMachineEnergy.java
+++ b/src/main/java/matteroverdrive/tile/MOTileEntityMachineEnergy.java
@@ -18,17 +18,20 @@
 
 package matteroverdrive.tile;
 
+import matteroverdrive.MatterOverdrive;
 import matteroverdrive.data.Inventory;
 import matteroverdrive.data.MachineEnergyStorage;
 import matteroverdrive.data.inventory.EnergySlot;
 import matteroverdrive.machines.MOTileEntityMachine;
 import matteroverdrive.machines.MachineNBTCategory;
+import matteroverdrive.network.packet.client.PacketPowerUpdate;
 import matteroverdrive.util.MOEnergyHelper;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.EnumFacing;
 import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.energy.CapabilityEnergy;
+import net.minecraftforge.fml.common.network.NetworkRegistry;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -107,7 +110,7 @@ public abstract class MOTileEntityMachineEnergy extends MOTileEntityMachine {
     }
 
     public void UpdateClientPower() {
-        //MatterOverdrive.packetPipeline.sendToAllAround(new PacketPowerUpdate(this), new NetworkRegistry.TargetPoint(world.provider.getDimension(), getPos().getX(), getPos().getY(), getPos().getZ(), ENERGY_CLIENT_SYNC_RANGE));
+        MatterOverdrive.packetPipeline.sendToAllAround(new PacketPowerUpdate(this), new NetworkRegistry.TargetPoint(world.provider.getDimension(), getPos().getX(), getPos().getY(), getPos().getZ(), ENERGY_CLIENT_SYNC_RANGE));
     }
 
     @Override


### PR DESCRIPTION
All batteries and weapons after change **will** lose their current energy.
All machines **have** to be replaced after update:
![lol](https://i.dbot.serealia.ca/2018/02/javaw_2018-02-15_18-51-04.png)

This PR changes seriable capabilities into regular NBT tags.
This workarounds https://github.com/MinecraftForge/MinecraftForge/issues/3483
Also this re-enables old code to send energy update packet to clients because it seems to be stable and working.

This fixes https://github.com/MatterOverdrive/MatterOverdrive/issues/45
This also fixes https://github.com/MatterOverdrive/MatterOverdrive/issues/41

*first pull request in minecraft modding ever*