### PR TITLE
Fixed two crashes and refactored variable names to match others

### DIFF
--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererAndroidStation.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererAndroidStation.java
@@ -38,6 +38,10 @@ public class TileEntityRendererAndroidStation extends TileEntityRendererStation<
 
     @Override
     protected void renderHologram(TileEntityAndroidStation station, double x, double y, double z, float partialTicks, double noise) {
+        if (station.getWorld().isAirBlock(station.getPos())) {
+            return;
+        }
+
         if ((station).isUsableByPlayer(Minecraft.getMinecraft().player)) {
             if (mob == null) {
                 mob = new EntityMeleeRougeAndroidMob(Minecraft.getMinecraft().world);

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererFusionReactorController.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererFusionReactorController.java
@@ -43,13 +43,13 @@ public class TileEntityRendererFusionReactorController extends TileEntitySpecial
     }
 
     @Override
-    public void render(TileEntityMachineFusionReactorController controller, double x, double y, double z, float ticks, int destoryStage, float a) {
-        if (!controller.isValidStructure()) {
+    public void render(TileEntityMachineFusionReactorController tileEntity, double x, double y, double z, float ticks, int destoryStage, float a) {
+        if (!tileEntity.isValidStructure()) {
             GlStateManager.pushMatrix();
             GlStateManager.translate(x, y, z);
 
             for (int i = 0; i < TileEntityMachineFusionReactorController.positionsCount; i++) {
-                Vec3d pos = controller.getPosition(i, getWorld().getBlockState(controller.getPos()).getValue(MOBlock.PROPERTY_DIRECTION));
+                Vec3d pos = tileEntity.getPosition(i, getWorld().getBlockState(tileEntity.getPos()).getValue(MOBlock.PROPERTY_DIRECTION));
 
                 GlStateManager.pushMatrix();
                 GlStateManager.translate(pos.x, pos.y, pos.z);
@@ -65,7 +65,7 @@ public class TileEntityRendererFusionReactorController extends TileEntitySpecial
             GlStateManager.popMatrix();
         }
 
-        renderInfo(x, y, z, controller);
+        renderInfo(x, y, z, tileEntity);
     }
 
     private void renderInfo(double x, double y, double z, TileEntityMachineFusionReactorController controller) {

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererGravitationalStabilizer.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererGravitationalStabilizer.java
@@ -45,18 +45,22 @@ public class TileEntityRendererGravitationalStabilizer extends TileEntitySpecial
     public static final ResourceLocation beam = new ResourceLocation(Reference.PATH_FX + "physbeam.png");
 
     @Override
-    public void render(TileEntityMachineGravitationalStabilizer stabilizer, double x, double y, double z, float ticks, int destroyStage, float a) {
-        if (stabilizer.getHit() != null) {
-            RayTraceResult hit = stabilizer.getHit();
-            TileEntity tileEntityHit = stabilizer.getWorld().getTileEntity(hit.getBlockPos());
+    public void render(TileEntityMachineGravitationalStabilizer tileEntity, double x, double y, double z, float ticks, int destroyStage, float a) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+        
+        if (tileEntity.getHit() != null) {
+            RayTraceResult hit = tileEntity.getHit();
+            TileEntity tileEntityHit = tileEntity.getWorld().getTileEntity(hit.getBlockPos());
 
 
             GlStateManager.pushMatrix();
             GlStateManager.translate(x + 0.5, y + 0.5, z + 0.5);
 
-            long time = stabilizer.getWorld().getWorldTime();
+            long time = tileEntity.getWorld().getWorldTime();
             double pulseSize = Math.sin(time * 0.2) * 0.001;
-            Vector3f source = new Vector3f(stabilizer.getPos().getX(), stabilizer.getPos().getY(), stabilizer.getPos().getZ());
+            Vector3f source = new Vector3f(tileEntity.getPos().getX(), tileEntity.getPos().getY(), tileEntity.getPos().getZ());
             Vector3f destination = new Vector3f((float) hit.hitVec.x, (float) hit.hitVec.y, (float) hit.hitVec.z);
             Vector3f dir = Vector3f.sub(destination, source, null);
             Vector3f dirC = Vector3f.cross(dir, new Vector3f(1, 0, 1), null);
@@ -73,7 +77,7 @@ public class TileEntityRendererGravitationalStabilizer extends TileEntitySpecial
             RenderUtils.disableLightmap();
 
             GlStateManager.blendFunc(GL_ONE, GL_ONE);
-            GlStateManager.color((float) stabilizer.getBeamColorR(), (float) stabilizer.getBeamColorG(), (float) stabilizer.getBeamColorB());
+            GlStateManager.color((float) tileEntity.getBeamColorR(), (float) tileEntity.getBeamColorG(), (float) tileEntity.getBeamColorB());
             bindTexture(beam);
 
             GlStateManager.pushMatrix();
@@ -103,7 +107,7 @@ public class TileEntityRendererGravitationalStabilizer extends TileEntitySpecial
             GlStateManager.popMatrix();
 
             if (tileEntityHit != null && tileEntityHit instanceof TileEntityGravitationalAnomaly) {
-                renderScreen(x, y, z, stabilizer, (TileEntityGravitationalAnomaly) tileEntityHit);
+                renderScreen(x, y, z, tileEntity, (TileEntityGravitationalAnomaly) tileEntityHit);
             }
         }
     }

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererHoloSign.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererHoloSign.java
@@ -34,30 +34,33 @@ import static matteroverdrive.util.MOBlockHelper.getRightSide;
  */
 public class TileEntityRendererHoloSign extends TileEntitySpecialRenderer<TileEntityHoloSign> {
     @Override
-    public void render(TileEntityHoloSign holoSign, double x, double y, double z, float ticks, int destoryStage, float a) {
-        EnumFacing side = holoSign.getWorld().getBlockState(holoSign.getPos()).getValue(MOBlock.PROPERTY_DIRECTION);
+    public void render(TileEntityHoloSign tileEntity, double x, double y, double z, float ticks, int destoryStage, float a) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
 
-        RenderUtils.beginDrawinngBlockScreen(x, y, z, side, Reference.COLOR_HOLO, holoSign, -0.8375, 0.2f);
+        EnumFacing side = tileEntity.getWorld().getBlockState(tileEntity.getPos()).getValue(MOBlock.PROPERTY_DIRECTION);
+        RenderUtils.beginDrawinngBlockScreen(x, y, z, side, Reference.COLOR_HOLO, tileEntity, -0.8375, 0.2f);
 
-        if (holoSign instanceof TileEntityHoloSign) {
-            String text = holoSign.getText();
+        if (tileEntity instanceof TileEntityHoloSign) {
+            String text = tileEntity.getText();
             if (text != null) {
                 String[] infos = text.split("\n");
                 int leftMargin = 10;
                 int rightMargin = 10;
                 float maxSize = 4f;
                 EnumFacing leftSide = getLeftSide(side);
-                if (holoSign.getWorld().getBlockState(holoSign.getPos().offset(leftSide)).getBlock() instanceof BlockHoloSign) {
+                if (tileEntity.getWorld().getBlockState(tileEntity.getPos().offset(leftSide)).getBlock() instanceof BlockHoloSign) {
                     leftMargin = 0;
                     maxSize = 8;
                 }
                 EnumFacing rightSide = getRightSide(side);
-                if (holoSign.getWorld().getBlockState(holoSign.getPos().offset(rightSide)).getBlock() instanceof BlockHoloSign) {
+                if (tileEntity.getWorld().getBlockState(tileEntity.getPos().offset(rightSide)).getBlock() instanceof BlockHoloSign) {
                     rightMargin = 0;
                     maxSize = 8;
                 }
 
-                if (holoSign.getConfigs().getBoolean("AutoLineSize", false)) {
+                if (tileEntity.getConfigs().getBoolean("AutoLineSize", false)) {
                     RenderUtils.drawScreenInfoWithLocalAutoSize(infos, Reference.COLOR_HOLO, side, leftMargin, rightMargin, maxSize);
                 } else {
                     RenderUtils.drawScreenInfoWithGlobalAutoSize(infos, Reference.COLOR_HOLO, side, leftMargin, rightMargin, maxSize);

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererMatterPipe.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererMatterPipe.java
@@ -16,12 +16,12 @@ public class TileEntityRendererMatterPipe extends TileEntityRendererPipe {
     }
 
     @Override
-    protected Vector2f getCoreUV(TileEntity entity) {
+    protected Vector2f getCoreUV(TileEntity tileEntity) {
         return new Vector2f(0, 0);
     }
 
     @Override
-    protected Vector2f getSidesUV(TileEntity entity, EnumFacing dir) {
+    protected Vector2f getSidesUV(TileEntity tileEntity, EnumFacing dir) {
         return new Vector2f(1, 0);
     }
 }

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererMonitor.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererMonitor.java
@@ -38,6 +38,10 @@ public abstract class TileEntityRendererMonitor<T extends MOTileEntityMachine> e
 
     @Override
     public void render(MOTileEntityMachine tileEntity, double x, double y, double z, float ticks, int destroyStage, float a) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
         GlStateManager.pushMatrix();
 
         IBlockState blockState = getWorld().getBlockState(tileEntity.getPos());

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererNetworkPipe.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererNetworkPipe.java
@@ -15,13 +15,13 @@ public class TileEntityRendererNetworkPipe extends TileEntityRendererPipe {
     }
 
     @Override
-    protected void drawCore(TileEntityPipe tile, double x,
+    protected void drawCore(TileEntityPipe tileEntity, double x,
                             double y, double z, float f, int sides) {
-        super.drawCore(tile, x, y, z, f, sides);
+        super.drawCore(tileEntity, x, y, z, f, sides);
     }
 
     @Override
-    protected void drawSide(TileEntityPipe tile, EnumFacing dir) {
-        super.drawSide(tile, dir);
+    protected void drawSide(TileEntityPipe tileEntity, EnumFacing dir) {
+        super.drawSide(tileEntity, dir);
     }
 }

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPacketQueue.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPacketQueue.java
@@ -34,6 +34,10 @@ public class TileEntityRendererPacketQueue extends TileEntitySpecialRenderer {
 
     @Override
     public void render(TileEntity tileEntity, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
         GlStateManager.pushMatrix();
         GlStateManager.translate(x, y, z);
         if (tileEntity instanceof TileEntityMachinePacketQueue) {

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPatterStorage.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPatterStorage.java
@@ -28,7 +28,7 @@ public class TileEntityRendererPatterStorage extends TileEntitySpecialRenderer<T
     }
 
     @Override
-    public void render(TileEntityMachinePatternStorage patternStorage, double x, double y, double z, float ticks, int destroyStage, float a) {
+    public void render(TileEntityMachinePatternStorage tileEntity, double x, double y, double z, float ticks, int destroyStage, float a) {
 		/*GL11.glPushMatrix();
 		GlStateManager.translate(x + 0.5f, y + 0.5f, z + 0.5f);
         RenderUtils.rotateFromBlock(patternStorage.getWorld(), patternStorage.getPos());

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPatternMonitor.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPatternMonitor.java
@@ -37,6 +37,10 @@ public class TileEntityRendererPatternMonitor extends TileEntityRendererMonitor 
 
     @Override
     public void drawScreen(TileEntity tileEntity, float ticks) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
         Minecraft.getMinecraft().renderEngine.bindTexture(screenTexture);
         glColor3f(Reference.COLOR_HOLO.getFloatR() * 0.7f, Reference.COLOR_HOLO.getFloatG() * 0.7f, Reference.COLOR_HOLO.getFloatB() * 0.7f);
 

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPipe.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererPipe.java
@@ -31,7 +31,11 @@ public class TileEntityRendererPipe extends TileEntitySpecialRenderer<TileEntity
     }
 
     @Override
-    public void render(TileEntityPipe pipe, double x, double y, double z, float f, int destroyStage, float a) {
+    public void render(TileEntityPipe tileEntity, double x, double y, double z, float f, int destroyStage, float a) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
         GlStateManager.pushMatrix();
 
         GlStateManager.translate(x, y, z);
@@ -39,7 +43,7 @@ public class TileEntityRendererPipe extends TileEntitySpecialRenderer<TileEntity
             this.bindTexture(texture);
         }
 
-        drawCore(pipe, x, y, z, f, drawSides(pipe, x, y, z, f));
+        drawCore(tileEntity, x, y, z, f, drawSides(tileEntity, x, y, z, f));
 
         GlStateManager.popMatrix();
     }

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererReplicator.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererReplicator.java
@@ -20,11 +20,15 @@ public class TileEntityRendererReplicator extends TileEntitySpecialRenderer<Tile
         GlStateManager.popMatrix();
     }
 
-    private void renderItem(TileEntityMachineReplicator replicator, double x, double y, double z) {
-        ItemStack stack = replicator.getStackInSlot(replicator.OUTPUT_SLOT_ID);
+    private void renderItem(TileEntityMachineReplicator tileEntity, double x, double y, double z) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
+        ItemStack stack = tileEntity.getStackInSlot(tileEntity.OUTPUT_SLOT_ID);
         if (!stack.isEmpty()) {
             if (itemEntity == null) {
-                itemEntity = new EntityItem(replicator.getWorld(), x, y, z, stack);
+                itemEntity = new EntityItem(tileEntity.getWorld(), x, y, z, stack);
             } else if (!ItemStack.areItemStacksEqual(itemEntity.getItem(), stack)) {
                 itemEntity.setItem(stack);
             }

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererStarMap.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererStarMap.java
@@ -55,7 +55,11 @@ public class TileEntityRendererStarMap extends TileEntityRendererStation<TileEnt
         renderHologramBase(starMap, x, y, z, partialTicks);
     }
 
-    protected void renderHologramBase(TileEntityMachineStarMap starMap, double x, double y, double z, float partialTicks) {
+    protected void renderHologramBase(TileEntityMachineStarMap tileEntity, double x, double y, double z, float partialTicks) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
         GlStateManager.pushMatrix();
         GlStateManager.translate(x, y, z);
         GlStateManager.translate(0.5, 0.5, 0.5);
@@ -65,29 +69,29 @@ public class TileEntityRendererStarMap extends TileEntityRendererStation<TileEnt
         GlStateManager.blendFunc(GL_ONE, GL_ONE);
         float distance = (float) new Vec3d(x, y, z).lengthVector();
 
-        if (starMap.getActiveSpaceBody() != null) {
-            Collection<ISpaceBodyHoloRenderer> renderers = ClientProxy.renderHandler.getStarmapRenderRegistry().getStarmapRendererCollection(starMap.getActiveSpaceBody().getClass());
+        if (tileEntity.getActiveSpaceBody() != null) {
+            Collection<ISpaceBodyHoloRenderer> renderers = ClientProxy.renderHandler.getStarmapRenderRegistry().getStarmapRendererCollection(tileEntity.getActiveSpaceBody().getClass());
             if (renderers != null) {
                 for (ISpaceBodyHoloRenderer renderer : renderers) {
-                    if (renderer.displayOnZoom(starMap.getZoomLevel(), starMap.getActiveSpaceBody())) {
-                        SpaceBody spaceBody = starMap.getActiveSpaceBody();
+                    if (renderer.displayOnZoom(tileEntity.getZoomLevel(), tileEntity.getActiveSpaceBody())) {
+                        SpaceBody spaceBody = tileEntity.getActiveSpaceBody();
                         if (spaceBody != null) {
                             GlStateManager.translate(0, renderer.getHologramHeight(spaceBody), 0);
                             GlStateManager.pushMatrix();
-                            renderer.renderBody(GalaxyClient.getInstance().getTheGalaxy(), spaceBody, starMap, partialTicks, distance);
+                            renderer.renderBody(GalaxyClient.getInstance().getTheGalaxy(), spaceBody, tileEntity, partialTicks, distance);
                             GlStateManager.popMatrix();
 
                             if (drawHoloLights()) {
                                 GlStateManager.pushMatrix();
                                 Vec3d playerPosition = Minecraft.getMinecraft().getRenderViewEntity().getPositionEyes(partialTicks);
                                 playerPosition = new Vec3d(playerPosition.x, 0, playerPosition.z);
-                                Vec3d mapPosition = new Vec3d(starMap.getPos().getX() + 0.5, 0, starMap.getPos().getZ() + 0.5);
+                                Vec3d mapPosition = new Vec3d(tileEntity.getPos().getX() + 0.5, 0, tileEntity.getPos().getZ() + 0.5);
                                 Vec3d dir = mapPosition.subtract(playerPosition).normalize();
                                 double angle = Math.acos(dir.dotProduct(new Vec3d(1, 0, 0)));
                                 if (new Vec3d(0, 1, 0).dotProduct(dir.crossProduct(new Vec3d(1, 0, 0))) < 0) {
                                     angle = Math.PI * 2 - angle;
                                 }
-                                drawHoloGuiInfo(renderer, spaceBody, starMap, (Math.PI / 2 - angle) * (180 / Math.PI), partialTicks);
+                                drawHoloGuiInfo(renderer, spaceBody, tileEntity, (Math.PI / 2 - angle) * (180 / Math.PI), partialTicks);
                                 GlStateManager.popMatrix();
                             }
                         }

--- a/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererWeaponStation.java
+++ b/src/main/java/matteroverdrive/client/render/tileentity/TileEntityRendererWeaponStation.java
@@ -3,13 +3,18 @@ package matteroverdrive.client.render.tileentity;
 import matteroverdrive.tile.TileEntityWeaponStation;
 import matteroverdrive.util.RenderUtils;
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.renderer.BufferBuilder;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
+import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureMap;
+import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
+
+import static org.lwjgl.opengl.GL11.GL_QUADS;
 
 /**
  * Created by Simeon on 4/17/2015.
@@ -23,17 +28,22 @@ public class TileEntityRendererWeaponStation extends TileEntityRendererStation<T
     }
 
     @Override
-    protected void renderHologram(TileEntityWeaponStation weaponStation, double x, double y, double z, float partialTicks, double noise) {
-        if (isUsable(weaponStation)) {
-            ItemStack stack = weaponStation.getStackInSlot(weaponStation.INPUT_SLOT);
+    protected void renderHologram(TileEntityWeaponStation tileEntity, double x, double y, double z, float partialTicks, double noise) {
+        if (tileEntity.getWorld().isAirBlock(tileEntity.getPos())) {
+            return;
+        }
+
+        if (isUsable(tileEntity)) {
+            ItemStack stack = tileEntity.getStackInSlot(tileEntity.INPUT_SLOT);
+
             if (!stack.isEmpty()) {
                 if (itemEntity == null) {
-                    itemEntity = new EntityItem(weaponStation.getWorld(), weaponStation.getPos().getX(), weaponStation.getPos().getY(), weaponStation.getPos().getZ(), stack);
+                    itemEntity = new EntityItem(tileEntity.getWorld(), tileEntity.getPos().getX(), tileEntity.getPos().getY(), tileEntity.getPos().getZ(), stack);
                 } else if (!ItemStack.areItemStacksEqual(itemEntity.getItem(), stack)) {
                     itemEntity.setItem(stack);
                 }
 
-                itemEntity.hoverStart = weaponStation.getWorld().getWorldTime();
+                itemEntity.hoverStart = tileEntity.getWorld().getWorldTime();
                 GlStateManager.translate(x + 0.5f, y + 0.8f, z + 0.5f);
                 GlStateManager.scale(0.5, 0.5, 0.5);
                 RenderHelper.enableStandardItemLighting();
@@ -42,10 +52,19 @@ public class TileEntityRendererWeaponStation extends TileEntityRendererStation<T
                 IBakedModel model = Minecraft.getMinecraft().getRenderItem().getItemModelMesher().getItemModel(stack);
                 model = net.minecraftforge.client.ForgeHooksClient.handleCameraTransforms(model, ItemCameraTransforms.TransformType.GROUND, false);
                 Minecraft.getMinecraft().getRenderItem().renderItem(stack, model);
+
+                BufferBuilder wr = Tessellator.getInstance().getBuffer();
+
+                try {
+                    wr.finishDrawing();
+                } catch (IllegalStateException e) {
+
+                }
+
                 RenderHelper.disableStandardItemLighting();
             }
         } else {
-            super.renderHologram(weaponStation, x, y, z, partialTicks, noise);
+            super.renderHologram(tileEntity, x, y, z, partialTicks, noise);
         }
     }
 }


### PR DESCRIPTION
This fixes https://github.com/MatterOverdrive/MatterOverdrive/issues/58
This also ~~fixes~~ workarounds crash with some items, like EvilCraft's Broom
```
java.lang.IllegalStateException: Already building!
    at net.minecraft.client.renderer.BufferBuilder.func_181668_a(BufferBuilder.java:187)
    at net.minecraft.client.shader.Framebuffer.func_178038_a(Framebuffer.java:264)
    at net.minecraft.client.renderer.RenderGlobal.func_174975_c(RenderGlobal.java:243)
    at net.minecraft.client.renderer.EntityRenderer.func_181560_a(EntityRenderer.java:1076)
    at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:1117)
    at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:397)
    at net.minecraft.client.main.Main.main(SourceFile:123)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
    at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
    at org.multimc.EntryPoint.listen(EntryPoint.java:143)
    at org.multimc.EntryPoint.main(EntryPoint.java:34)
```