### PR TITLE
Fixed WeaponFactory checks

### DIFF
--- a/src/main/java/matteroverdrive/data/WeightedRandomItemStack.java
+++ b/src/main/java/matteroverdrive/data/WeightedRandomItemStack.java
@@ -21,18 +21,20 @@ package matteroverdrive.data;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.WeightedRandom;
 
+import javax.annotation.Nonnull;
+
 /**
  * Created by Simeon on 12/23/2015.
  */
 public class WeightedRandomItemStack extends WeightedRandom.Item {
     private final ItemStack stack;
 
-    public WeightedRandomItemStack(ItemStack stack) {
+    public WeightedRandomItemStack(@Nonnull ItemStack stack) {
 
         this(stack, 100);
     }
 
-    public WeightedRandomItemStack(ItemStack stack, int weight) {
+    public WeightedRandomItemStack(@Nonnull ItemStack stack, int weight) {
 
         super(weight);
         this.stack = stack;

--- a/src/main/java/matteroverdrive/util/WeaponFactory.java
+++ b/src/main/java/matteroverdrive/util/WeaponFactory.java
@@ -273,16 +273,21 @@ public class WeaponFactory {
         }
 
         public boolean fits(WeaponGenerationContext context) {
+            if (weaponModule == null || weaponModule.isEmpty()) {
+                return false;
+            }
+
             boolean weaponSupportModule = false;
-            if (context.weaponStack != null && context.weaponStack.getItem() instanceof IWeapon) {
+
+            if (context.weaponStack != null && !context.weaponStack.isEmpty() && context.weaponStack.getItem() instanceof IWeapon) {
                 weaponSupportModule = context.weaponStack.getItem() instanceof IWeapon && ((IWeapon) context.weaponStack.getItem()).supportsModule(context.weaponStack, weaponModule);
             }
 
             if (legendary && !context.legendary) {
                 return weaponSupportModule;
             }
-            return context.level >= minLevel && context.level <= maxLevel && weaponSupportModule;
 
+            return context.level >= minLevel && context.level <= maxLevel && weaponSupportModule;
         }
     }
     //endregion


### PR DESCRIPTION
If `WeaponFactory` never should produce null modules, please close this and resolve in another way
This fixes https://github.com/MatterOverdrive/MatterOverdrive/issues/64