### PR TITLE
Move world gen initialization to pre-init

### DIFF
--- a/src/main/java/matteroverdrive/MatterOverdrive.java
+++ b/src/main/java/matteroverdrive/MatterOverdrive.java
@@ -154,7 +154,7 @@ public class MatterOverdrive {
 
         MatterOverdriveEntities.init(event, CONFIG_HANDLER);
         MatterOverdriveEnchantments.init(event, CONFIG_HANDLER);
-        MO_WORLD.register();
+        MO_WORLD.init(CONFIG_HANDLER);
         MatterNetworkRegistry.register();
         NETWORK.registerPackets();
         OverdriveBioticStats.registerAll(CONFIG_HANDLER, STAT_REGISTRY);

--- a/src/main/java/matteroverdrive/init/MatterOverdriveWorld.java
+++ b/src/main/java/matteroverdrive/init/MatterOverdriveWorld.java
@@ -33,19 +33,20 @@ public class MatterOverdriveWorld {
     private final DimensionalRifts dimensionalRifts;
 
     public MatterOverdriveWorld(ConfigurationHandler configurationHandler) {
-        worldGen = new MOWorldGen(configurationHandler);
+        worldGen = new MOWorldGen();
         dimensionalRifts = new DimensionalRifts(1);
         configurationHandler.subscribe(worldGen);
+    }
+
+    public void init(ConfigurationHandler configurationHandler) {
+        worldGen.init(configurationHandler);
+        GameRegistry.registerWorldGenerator(worldGen, 0);
     }
 
     public void onWorldTick(TickEvent.WorldTickEvent event) {
         if (event.side.equals(Side.SERVER)) {
             worldGen.manageBuildingGeneration();
         }
-    }
-
-    public void register() {
-        GameRegistry.registerWorldGenerator(worldGen, 0);
     }
 
     public DimensionalRifts getDimensionalRifts() {

--- a/src/main/java/matteroverdrive/world/MOWorldGen.java
+++ b/src/main/java/matteroverdrive/world/MOWorldGen.java
@@ -62,23 +62,27 @@ public class MOWorldGen implements IWorldGenerator, IConfigSubscriber {
     boolean generateAnomalies;
     boolean generateBuildings = true;
 
-    public MOWorldGen(ConfigurationHandler configurationHandler) {
+    public MOWorldGen() {
         oreRandom = new Random();
         anomaliesRandom = new Random();
         buildingsRandom = new Random();
         buildings = new ArrayList<>();
         worldGenBuildingQueue = new ArrayDeque<>();
 
+        oreDimentionsBlacklist = new HashSet<>();
+    }
+
+    public void init(ConfigurationHandler configurationHandler) {
         tritaniumGen = new WorldGenMinable(MatterOverdrive.BLOCKS.tritaniumOre.getDefaultState(), TRITANIUM_VEIN_SIZE);
         dilithiumGen = new WorldGenMinable(MatterOverdrive.BLOCKS.dilithium_ore.getDefaultState(), DILITHIUM_VEIN_SIZE);
+
         buildings.add(new WeightedRandomMOWorldGenBuilding(new MOAndroidHouseBuilding("android_house"), 40));
         buildings.add(new WeightedRandomMOWorldGenBuilding(new MOSandPit("sand_pit_house", 3), 100));
         buildings.add(new WeightedRandomMOWorldGenBuilding(new MOWorldGenCrashedSpaceShip("crashed_ship"), 75));
         buildings.add(new WeightedRandomMOWorldGenBuilding(new MOWorldGenUnderwaterBase("underwater_base"), 30));
         buildings.add(new WeightedRandomMOWorldGenBuilding(new MOWorldGenCargoShip("cargo_ship"), 5));
-        anomalyGen = new WorldGenGravitationalAnomaly("gravitational_anomaly", 0.05f, 2048, 2048 + 8192);
-        oreDimentionsBlacklist = new HashSet<>();
 
+        anomalyGen = new WorldGenGravitationalAnomaly("gravitational_anomaly", 0.05f, 2048, 2048 + 8192);
         configurationHandler.subscribe(anomalyGen);
     }
 


### PR DESCRIPTION
Fixes crash during mod construction due to uninitialized blocks.

The crash was introduced in cf83e04ec152e9eaf00ab31e9b0d7b9617a2f6d5 when MatterOverdriveWorld construction was moved to the static block from pre-init.