### PR TITLE
Rotate minimap 180 deg to correctly align

### DIFF
--- a/src/main/java/matteroverdrive/gui/android/AndroidHudMinimap.java
+++ b/src/main/java/matteroverdrive/gui/android/AndroidHudMinimap.java
@@ -206,7 +206,7 @@ public class AndroidHudMinimap extends AndroidHudElement {
             opacity *= baseColor.getFloatA();
             GlStateManager.enableTexture2D();
             RenderUtils.applyColorWithAlpha(color, OPACITY * opacity);
-            GlStateManager.rotate(mc.getRenderViewEntity().rotationYaw, 0, 0, -1);
+            GlStateManager.rotate(mc.getRenderViewEntity().rotationYaw + 180, 0, 0, -1);
             GlStateManager.translate(pos.x, pos.z, 0);
             GlStateManager.rotate(entityLivingBase.getRotationYawHead(), 0, 0, 1);
             GlStateManager.disableTexture2D();


### PR DESCRIPTION
I'm not entirely sure why this bug occurred in the first place, but rotating all entities 180 degrees fixes it.
![2018-03-06_21 14 11](https://user-images.githubusercontent.com/7091588/37069883-53e8b6a6-2183-11e8-96f6-2cc98456e6aa.png)
